### PR TITLE
sort image files to get correct startFrame

### DIFF
--- a/scripts/butil/seq_config.py
+++ b/scripts/butil/seq_config.py
@@ -126,7 +126,7 @@ def make_seq_configs(loadSeqs):
                     + 'check if config.py\'s DOWNLOAD_SEQS is True'
                 sys.exit(1)
 
-        imgfiles = os.listdir(imgSrc)
+        imgfiles = sorted(os.listdir(imgSrc))
         imgfiles = [x for x in imgfiles if x.split('.')[1] in ['jpg', 'png']]
         nz, ext, startFrame, endFrame = get_format(name, imgfiles)
         


### PR DESCRIPTION
In linux system, os.listdir() seems to return unsorted filenames which breaks the get_format() since it simply use the first returned filename  as the startFrame.